### PR TITLE
Change numberOfPages to computed property.

### DIFF
--- a/RDImageViewerController/Classes/PagingView.swift
+++ b/RDImageViewerController/Classes/PagingView.swift
@@ -171,7 +171,14 @@ open class PagingView: UICollectionView {
     public weak var pagingDataSource: (PagingViewDataSource & UICollectionViewDataSource)?
     public weak var pagingDelegate: (PagingViewDelegate & UICollectionViewDelegate & UICollectionViewDelegateFlowLayout)?
         
-    public var numberOfPages = 0
+    public var numberOfPages: Int {
+        get {
+            guard let pagingDataSource = pagingDataSource else {
+                return 0
+            }
+            return pagingDataSource.collectionView(self, numberOfItemsInSection: 0)
+        }
+    }
     public var preloadCount: Int = 3
     
     private var _isRotating: Bool = false
@@ -336,10 +343,7 @@ open class PagingView: UICollectionView {
     }
     
     open override func reloadData() {
-        guard let pagingDataSource = pagingDataSource else {
-            return
-        }
-        numberOfPages = pagingDataSource.collectionView(self, numberOfItemsInSection: 0)
+        self.collectionViewLayout.invalidateLayout()
         super.reloadData()
     }
     
@@ -457,11 +461,9 @@ extension PagingView : UICollectionViewDataSource
     
     public func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
         guard let pagingDataSource = pagingDataSource else {
-            numberOfPages = 0
-            return numberOfPages
+            return 0
         }
-        numberOfPages = pagingDataSource.collectionView(collectionView, numberOfItemsInSection: section)
-        return numberOfPages
+        return pagingDataSource.collectionView(collectionView, numberOfItemsInSection: section)
     }
     
     public func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {

--- a/RDImageViewerController/Classes/RDImageViewerController.swift
+++ b/RDImageViewerController/Classes/RDImageViewerController.swift
@@ -568,17 +568,19 @@ open class RDImageViewerController: UIViewController, UICollectionViewDelegateFl
     }
     
     public func reloadView(at index: Int) {
-        if numberOfPages > index {
-            let data = contents[index]
-            data.reload()
-            refreshView(at: index)
+        if index < 0 || (numberOfPages - 1) < index {
+            return
         }
+        let data = contents[index]
+        data.reload()
+        refreshView(at: index)
     }
     
     public func refreshView(at index: Int) {
-        if numberOfPages > index, index >= 0 {
-            pagingView.reloadItems(at: [IndexPath(row: index, section: 0)])
+        if index < 0 || (numberOfPages - 1) < index {
+            return
         }
+        pagingView.reloadItems(at: [IndexPath(row: index, section: 0)])
     }
     
     open func changeDirection(_ forwardDirection: PagingView.ForwardDirection) {


### PR DESCRIPTION
- numberOfPages is changed to a computed property, to avoid data inconsistency.
- call `self.collectionViewLayout.invalidateLayout()` in `reloadData()` to avoid `NSInternalInconsistencyException`
  - See: https://github.com/Instagram/IGListKit/issues/813
