### PR TITLE
Check indexies before accessing elements in contents

### DIFF
--- a/RDImageViewerController/Classes/RDImageViewerController.swift
+++ b/RDImageViewerController/Classes/RDImageViewerController.swift
@@ -692,6 +692,9 @@ open class RDImageViewerController: UIViewController, UICollectionViewDelegateFl
     }
 
     open func pagingView(pagingView: PagingView, preloadItemAt index: Int) {
+        if index < 0 || contents.count - 1 < index {
+            return;
+        }
         let data = contents[index]
         if data.isPreloadable() && !data.isPreloading() {
             data.preload()
@@ -699,6 +702,9 @@ open class RDImageViewerController: UIViewController, UICollectionViewDelegateFl
     }
     
     open func pagingView(pagingView: PagingView, cancelPreloadingItemAt index: Int) {
+        if index < 0 || contents.count - 1 < index {
+            return;
+        }
         let data = contents[index]
         if data.isPreloadable() && data.isPreloading() {
             data.stopPreload()


### PR DESCRIPTION
to avoid EXC_BREAKPOINT.

```
0x102c384bc specialized RDImageViewerController.pagingView(pagingView:willChangeIndexTo:currentIndex:) + 30 (RemoteImageContent.swift:30)
```